### PR TITLE
Fix a few nits helping to compile properly on stable/13 

### DIFF
--- a/iwmbt_hw.c
+++ b/iwmbt_hw.c
@@ -222,7 +222,7 @@ iwmbt_patch_fwfile(struct libusb_device_handle *hdl,
 			fw_job.len -= evt_length;
 
 			if (skip_patch == 0) {
-				iwmbt_hci_command(hdl,
+				ret = iwmbt_hci_command(hdl,
 				    (struct iwmbt_hci_cmd *)cmd_buf,
 				    evt_buf,
 				    IWMBT_HCI_MAX_EVENT_SIZE,
@@ -341,7 +341,6 @@ int
 iwmbt_enter_manufacturer(struct libusb_device_handle *hdl)
 {
 	int ret, transferred;
-	struct iwmbt_hci_event_cmd_compl*event;
 	static struct iwmbt_hci_cmd cmd = {
 		.opcode = htole16(0xfc11),
 		.length = 2,
@@ -370,7 +369,6 @@ int
 iwmbt_exit_manufacturer(struct libusb_device_handle *hdl, int mode)
 {
 	int ret, transferred;
-	struct iwmbt_hci_event_cmd_compl*event;
 	static struct iwmbt_hci_cmd cmd = {
 		.opcode = htole16(0xfc11),
 		.length = 2,

--- a/main.c
+++ b/main.c
@@ -51,7 +51,7 @@
 
 int	iwmbt_do_debug = 0;
 int	iwmbt_do_info = 0;
-int	iwmbt_use_old_method = 0;
+static int	iwmbt_use_old_method = 0;
 
 struct iwmbt_devid {
 	uint16_t product_id;


### PR DESCRIPTION
- iwmbt_use_old_method is static in main.c
- check return code of iwmbt_hci_command in iwmbt_patch_fwfile()
- remove unused variables in iwmbt_enter_manufacturer() and iwmbt_exit_manufacturer()
